### PR TITLE
os_family: Normalize to windows instead of winnt

### DIFF
--- a/lib/chef-rundeck.rb
+++ b/lib/chef-rundeck.rb
@@ -171,7 +171,7 @@ def build_node (node, username, hostname, custom_attributes)
       # Certain features in Rundeck require the osFamily value to be set to 'unix' to work appropriately. - SRK
       #++
       data = ''
-      os_family = node['kernel_os'] =~ /winnt|windows/i ? 'winnt' : 'unix'
+      os_family = node['kernel_os'] =~ /winnt|windows/i ? 'windows' : 'unix'
       nodeexec = node['kernel_os'] =~ /winnt|windows/i ? "node-executor=\"overthere-winrm\"" : ''
       data << <<-EOH
 <node name="#{xml_escape(node['fqdn'])}" #{nodeexec} 


### PR DESCRIPTION
Rundeck check explicitely to 'windows', otherwise it applies a `chmod +x` on the copied script